### PR TITLE
Solve the cuBLASS problem

### DIFF
--- a/01-basic-image-classification/resnet_cifar.py
+++ b/01-basic-image-classification/resnet_cifar.py
@@ -20,6 +20,13 @@ NUM_TRAIN_SAMPLES = 50000
 BASE_LEARNING_RATE = 0.1
 LR_SCHEDULE = [(0.1, 30), (0.01, 45)]
 
+config = tf.compat.v1.ConfigProto(gpu_options = 
+                         tf.compat.v1.GPUOptions(per_process_gpu_memory_fraction=0.8)
+# device_count = {'GPU': 1}
+)
+config.gpu_options.allow_growth = True
+session = tf.compat.v1.Session(config=config)
+tf.compat.v1.keras.backend.set_session(session)
 
 def normalize(x, y):
   x = tf.image.per_image_standardization(x)


### PR DESCRIPTION
2020-11-24 17:10:40.968133: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library cublas64_11.dll
2020-11-24 17:10:41.561920: E tensorflow/stream_executor/cuda/cuda_blas.cc:226] failed to create cublas handle: CUBLAS_STATUS_ALLOC_FAILED
2020-11-24 17:10:41.600418: E tensorflow/stream_executor/cuda/cuda_blas.cc:226] failed to create cublas handle: CUBLAS_STATUS_ALLOC_FAILED
2020-11-24 17:10:41.616474: E tensorflow/stream_executor/cuda/cuda_blas.cc:226] failed to create cublas handle: CUBLAS_STATUS_ALLOC_FAILED
2020-11-24 17:10:41.634211: E tensorflow/stream_executor/cuda/cuda_blas.cc:226] failed to create cublas handle: CUBLAS_STATUS_ALLOC_FAILED
2020-11-24 17:10:41.639599: E tensorflow/stream_executor/cuda/cuda_blas.cc:226] failed to create cublas handle: CUBLAS_STATUS_ALLOC_FAILED
2020-11-24 17:10:41.652798: E tensorflow/stream_executor/cuda/cuda_blas.cc:226] failed to create cublas handle: CUBLAS_STATUS_ALLOC_FAILED
2020-11-24 17:10:41.661381: E tensorflow/stream_executor/cuda/cuda_blas.cc:226] failed to create cublas handle: CUBLAS_STATUS_ALLOC_FAILED
2020-11-24 17:10:41.668742: E tensorflow/stream_executor/cuda/cuda_blas.cc:226] failed to create cublas handle: CUBLAS_STATUS_ALLOC_FAILED
2020-11-24 17:10:41.681011: E tensorflow/stream_executor/cuda/cuda_blas.cc:226] failed to create cublas handle: CUBLAS_STATUS_ALLOC_FAILED
2020-11-24 17:10:41.686750: E tensorflow/stream_executor/cuda/cuda_blas.cc:226] failed to create cublas handle: CUBLAS_STATUS_ALLOC_FAILED
2020-11-24 17:10:41.686793: W tensorflow/stream_executor/stream.cc:1455] attempting to perform BLAS operation using StreamExecutor without BLAS support
Traceback (most recent call last):
  File "resnet_cifar.py", line 96, in <module>
    model.fit(train_dataset,
  File "C:\Users\GPU2\Anaconda3\envs\rtx3000s\lib\site-packages\tensorflow\python\keras\engine\training.py", line 1132, in fit
    tmp_logs = self.train_function(iterator)
  File "C:\Users\GPU2\Anaconda3\envs\rtx3000s\lib\site-packages\tensorflow\python\eager\def_function.py", line 784, in __call__
    result = self._call(*args, **kwds)
  File "C:\Users\GPU2\Anaconda3\envs\rtx3000s\lib\site-packages\tensorflow\python\eager\def_function.py", line 844, in _call
    return self._stateless_fn(*args, **kwds)
  File "C:\Users\GPU2\Anaconda3\envs\rtx3000s\lib\site-packages\tensorflow\python\eager\function.py", line 2971, in __call__
    return graph_function._call_flat(
  File "C:\Users\GPU2\Anaconda3\envs\rtx3000s\lib\site-packages\tensorflow\python\eager\function.py", line 1947, in _call_flat
    return self._build_call_outputs(self._inference_function.call(
  File "C:\Users\GPU2\Anaconda3\envs\rtx3000s\lib\site-packages\tensorflow\python\eager\function.py", line 556, in call
    outputs = execute.execute(
  File "C:\Users\GPU2\Anaconda3\envs\rtx3000s\lib\site-packages\tensorflow\python\eager\execute.py", line 59, in quick_execute
    tensors = pywrap_tfe.TFE_Py_Execute(ctx._handle, device_name, op_name,
tensorflow.python.framework.errors_impl.InternalError: 2 root error(s) found.
  (0) Internal:  Blas xGEMM launch failed : a.shape=[1,256,64], b.shape=[1,64,10], m=256, n=10, k=64
         [[node resnet56/fc10/MatMul (defined at \threading.py:932) ]]
         [[div_no_nan/ReadVariableOp_1/_6]]
  (1) Internal:  Blas xGEMM launch failed : a.shape=[1,256,64], b.shape=[1,64,10], m=256, n=10, k=64
         [[node resnet56/fc10/MatMul (defined at \threading.py:932) ]]
0 successful operations.
0 derived errors ignored. [Op:__inference_train_function_18487]